### PR TITLE
fix: non-existing types now throw proper error message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -284,7 +284,7 @@ function cast(value, type) {
             return converter(value);
         }
         else {
-            throw new Error("Unknown type " + name);
+            throw new Error("Unknown type " + type);
         }
     }
     else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,7 @@ export function cast (value, type) {
       return converter(value);
     }
     else {
-      throw new Error(`Unknown type ${name}`);
+      throw new Error(`Unknown type ${type}`);
     }
   }
   else {

--- a/tests/index.js
+++ b/tests/index.js
@@ -315,4 +315,5 @@ test('cast (custom type)', (t) => {
   t.deepEqual(typeable.cast('foo', (v) => `${v}-bar`), 'foo-bar');
   t.deepEqual(typeable.cast('foo', [(v) => `${v}-bar`]), ['foo-bar']);
   t.deepEqual(typeable.cast(['foo0', 'foo1'], [(v) => `${v}-bar`]), ['foo0-bar', 'foo1-bar']);
+  t.throws(() => { typeable.cast({ my: 'object' }, 'object') }, 'Unknown type object');
 });


### PR DESCRIPTION
Fixed an issue where using non-existing types would throw `ReferenceError: name is not defined` instead of `Error: Unknown type ${type}`